### PR TITLE
Only read the game save file in case the folder contains other files

### DIFF
--- a/server/start.py
+++ b/server/start.py
@@ -33,7 +33,7 @@ class LedgerServer(BaseHTTPRequestHandler):
             saves = []
             for i in games:
                 
-                svs = [path + '/' + i + '/' + j for j in os.listdir(path + '/' + i)]
+                svs = [path + '/' + i + '/' + j for j in os.listdir(path + '/' + i) if j.endswith(".sav")]
                 
                 saves.extend(svs)
             if (len(saves)):


### PR DESCRIPTION
Players/Modders may put additional files into the save game directory, for instance unzip the .sav files in the same folder. My change avoids the tool reading incorrect files.