### PR TITLE
Indicate the web page is in UTF-8

### DIFF
--- a/server/base.html
+++ b/server/base.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>Stellaris Ledger</title>
         <style>
             body{


### PR DESCRIPTION
It solves the problem that if the country names are Unicode characters, the web page shows garbled text.