### PR TITLE
Show research income with penalty

### DIFF
--- a/server/base.html
+++ b/server/base.html
@@ -132,9 +132,9 @@
                 <th>Mineral Income</th>
                 <th>Influence</th>
                 <th>Influence Income</th>
-                <th>Physics Research Income with Penalty</th>
-                <th>Society Research Income with Penalty</th>
-                <th>Engineering Research Income with Penalty</th>
+                <th>Physics Income with Penalty</th>
+                <th>Society Income with Penalty</th>
+                <th>Engineering Income with Penalty</th>
                 <th>Population</th>
             </tr>
             </thead>

--- a/server/base.html
+++ b/server/base.html
@@ -132,6 +132,7 @@
                 <th>Mineral Income</th>
                 <th>Influence</th>
                 <th>Influence Income</th>
+                <th>Population</th>
             </tr>
             </thead>
             <tbody>

--- a/server/base.html
+++ b/server/base.html
@@ -132,6 +132,9 @@
                 <th>Mineral Income</th>
                 <th>Influence</th>
                 <th>Influence Income</th>
+                <th>Physics Research Income with Penalty</th>
+                <th>Society Research Income with Penalty</th>
+                <th>Engineering Research Income with Penalty</th>
                 <th>Population</th>
             </tr>
             </thead>

--- a/server/ledger.py
+++ b/server/ledger.py
@@ -55,6 +55,20 @@ class Country:
         self.score += NUM_COLONIES_MULTIPLIER * self.numcolonies
         self.score += NUM_PLANETS_MULTIPLIER * self.numplanets
 
+    def _getResearchPenalty(self):
+        return  0.1 * max(0, self.numcolonies -1) + 0.01 * max(0, self.population-10)
+
+    def getPhysicsResearchWithPenalty(self):
+        return self.physicsResearch / (1 + self._getResearchPenalty())
+
+
+    def getSocietyResearchWithPenalty(self):
+        return self.societyResearch / (1 + self._getResearchPenalty())
+
+    def getEngineeringResearchWithPenalty(self):
+        return self.engineeringResearch / (1 + self._getResearchPenalty())
+
+
 
 def getMatchedScope(text, scopeName):
     countries = text[text.find(scopeName+'={'):]
@@ -283,6 +297,9 @@ def makeLedgerForSave(path, basePath):
             ret2 += '<td>{:10.0f}</td>'.format(country.currentinfluence) + netincome
 
 
+            ret2 += '<td>%.1f</td>' % country.getPhysicsResearchWithPenalty()
+            ret2 += '<td>%.1f</td>' % country.getSocietyResearchWithPenalty()
+            ret2 += '<td>%.1f</td>' % country.getEngineeringResearchWithPenalty()
             ret2 += '<td>%d</td>' % country.population
             ret2 += '</tr>'
             retlist.append((country.id, ret2))

--- a/server/ledger.py
+++ b/server/ledger.py
@@ -27,6 +27,11 @@ class Country:
         self.energyproduction = 0
         self.mineralproduction = 0
         self.influenceproduction = 0
+
+        self.physicsResearch = 0
+        self.societyResearch = 0
+        self.engineeringResearch = 0
+
         self.numsubjects = 0
         self.militarypower = 0
         self.numcolonies = 0
@@ -208,6 +213,27 @@ def makeLedgerForSave(path, basePath):
                                 country.influenceproduction = float(influence)
                             else:
                                 country.influenceproduction = float(influence[0])
+
+                        physicsResearch=paradoxparser.paradox_dict_get_child_by_name(lastmonthmodule, 'physics_research')
+                        if(physicsResearch is not None):
+                            if (type(physicsResearch) == str):
+                                country.physicsResearch = float(physicsResearch)
+                            else:
+                                country.physicsResearch = float(physicsResearch[0])
+
+                        societyResearch=paradoxparser.paradox_dict_get_child_by_name(lastmonthmodule, 'society_research')
+                        if(societyResearch is not None):
+                            if (type(societyResearch) == str):
+                                country.societyResearch = float(societyResearch)
+                            else:
+                                country.societyResearch = float(societyResearch[0])
+
+                        engineeringResearch=paradoxparser.paradox_dict_get_child_by_name(lastmonthmodule, 'engineering_research')
+                        if(engineeringResearch is not None):
+                            if (type(engineeringResearch) == str):
+                                country.engineeringResearch = float(engineeringResearch)
+                            else:
+                                country.engineeringResearch = float(engineeringResearch[0])
 
             country.calcscore()
             ret2 += '<tr>'

--- a/server/ledger.py
+++ b/server/ledger.py
@@ -69,28 +69,21 @@ def makeLedgerForSave(path, basePath):
     countries = s[s.find('country={'):]
 
     t = 1
-    cdata = []
-    csdata = ''
     instring = False
     for i in range(len('country={') + 1, len(countries)):
         if countries[i] == '{' and not instring:
             if (t == 1):
-                csdata = ''
                 k = countries[i-1]
                 j = i-1
                 while(k != '\t'):
-                    csdata = k + csdata
                     j -= 1
                     k = countries[j]
             t += 1
         elif countries[i] == '}' and not instring:
             t -= 1
-            if (t == 1):
-                cdata.append(csdata + '}')
         elif countries[i] == '"':
             instring = not instring
 
-        csdata += countries[i]
         if (t == 0):
             countries = countries[:i+1]
             break

--- a/server/ledger.py
+++ b/server/ledger.py
@@ -32,6 +32,8 @@ class Country:
         self.societyResearch = 0
         self.engineeringResearch = 0
 
+        self.population = 0
+
         self.numsubjects = 0
         self.militarypower = 0
         self.numcolonies = 0
@@ -97,6 +99,9 @@ def makeLedgerForSave(path, basePath):
 
     country_raw_data = getMatchedScope(s,"country")[0][1]
 
+    planets = getMatchedScope(s,"planet")[0][1]
+
+
     ret = ''
 
     retlist = []
@@ -158,6 +163,15 @@ def makeLedgerForSave(path, basePath):
             controlledplanetsspart = paradoxparser.paradox_dict_get_child_by_name(i[1], 'owned_planets')
             if (controlledplanetsspart is not None):
                 country.numcolonies = len(controlledplanetsspart)
+
+                country.population = 0
+                for planetId in controlledplanetsspart:
+                    planetObject=planets[int(planetId)][1]
+
+                    popObject= next((x[1] for x in planetObject if x[0]=='pop'),None)
+                    # if the planet is under colonization, it doesn't have pop key.
+                    if(popObject is not None):
+                        country.population+=len(popObject)
 
             modulespart = paradoxparser.paradox_dict_get_child_by_name(i[1], 'modules')
             if (modulespart is not None):
@@ -269,6 +283,7 @@ def makeLedgerForSave(path, basePath):
             ret2 += '<td>{:10.0f}</td>'.format(country.currentinfluence) + netincome
 
 
+            ret2 += '<td>%d</td>' % country.population
             ret2 += '</tr>'
             retlist.append((country.id, ret2))
             num += 1

--- a/server/ledger.py
+++ b/server/ledger.py
@@ -53,6 +53,35 @@ class Country:
         self.score += NUM_COLONIES_MULTIPLIER * self.numcolonies
         self.score += NUM_PLANETS_MULTIPLIER * self.numplanets
 
+
+def getMatchedScope(text, scopeName):
+    countries = text[text.find(scopeName+'={'):]
+
+    t = 1
+    instring = False
+    for country_key_value_pair in range(len(scopeName+'={') + 1, len(countries)):
+        if countries[country_key_value_pair] == '{' and not instring:
+            if (t == 1):
+                k = countries[country_key_value_pair-1]
+                j = country_key_value_pair-1
+                while(k != '\t'):
+                    j -= 1
+                    k = countries[j]
+            t += 1
+        elif countries[country_key_value_pair] == '}' and not instring:
+            t -= 1
+        elif countries[country_key_value_pair] == '"':
+            instring = not instring
+
+        if (t == 0):
+            countries = countries[:country_key_value_pair+1]
+            break
+
+
+    result = paradoxparser.psr.parse(countries)
+    return result
+
+
 def makeLedgerForSave(path, basePath):
     save = zipfile.ZipFile(path)
     f = save.open('gamestate')
@@ -66,34 +95,7 @@ def makeLedgerForSave(path, basePath):
 
     playercountry = playertag[playertag.find('country=')+len('country='):playertag.find('}')].strip()
 
-    countries = s[s.find('country={'):]
-
-    t = 1
-    instring = False
-    for i in range(len('country={') + 1, len(countries)):
-        if countries[i] == '{' and not instring:
-            if (t == 1):
-                k = countries[i-1]
-                j = i-1
-                while(k != '\t'):
-                    j -= 1
-                    k = countries[j]
-            t += 1
-        elif countries[i] == '}' and not instring:
-            t -= 1
-        elif countries[i] == '"':
-            instring = not instring
-
-        if (t == 0):
-            countries = countries[:i+1]
-            break
-
-
-    result = paradoxparser.psr.parse(countries)
-
-
-    country_raw_data = result[0][1]
-
+    country_raw_data = getMatchedScope(s,"country")[0][1]
 
     ret = ''
 


### PR DESCRIPTION
The cost of a technology increases by the country's number of planets and number of population. If player wants to know how fast his research is, he has to divide research income by the mentioned penalty. 

Current the ledger shows neither research income nor population.

This pull request adds Physics, Society, and Engineering Income, the ones with penalty, and population, as the screenshot shows.

![chrome_2018-03-24_01-32-41](https://user-images.githubusercontent.com/614159/37862003-52cb32c0-2f03-11e8-87b4-8b99020a2c6c.png)

The table may look a bit busy. I'm fine you seek other ways to optimize this. Also for your information, there are JavaScript libraries that can help users show/hide columns.

I didn't update the score column. I don't know how you figure out weights. 

One maintenance cost is that the penalty formula, defined in `ledger.Country#_getResearchPenalty` has to update when Stellaris changes.

