### PR TITLE
Improve color contract radio to 4.5:1, WCAG 2.0 AA standard

### DIFF
--- a/server/base.html
+++ b/server/base.html
@@ -4,7 +4,7 @@
         <title>Stellaris Ledger</title>
         <style>
             body{
-                background-color: #06233b;
+                background-color: #001828;
             }
 
             table#ledger {
@@ -18,7 +18,7 @@
             }
 
             #ledger tr:nth-child(2n) {
-                background-color: #113348;
+                background-color: #0c2e43;
             }
             #ledger tr:nth-child(2n+1) {
                 background-color: transparent;
@@ -36,7 +36,7 @@
             }
 
             #ledger td.negative{
-                color: #d62114;
+                color: #FF5757;
             }
 
         </style>


### PR DESCRIPTION
The original color schema has low contrast radio, a bit harder to read. 

This pull request improves  color contract radio to 4.5:1 based on [WCAG 2.0 AA standard](https://www.w3.org/TR/WCAG20-TECHS/G18.html).

The radio is calculated by [HTML CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/).

The screenshots illustrate the color before and after the change.

![chrome_2018-03-24_10-36-21](https://user-images.githubusercontent.com/614159/37867021-dee9bc8a-2f4f-11e8-957a-7924b2ca98b4.png)

![chrome_2018-03-24_10-33-13](https://user-images.githubusercontent.com/614159/37867020-ded6affa-2f4f-11e8-94f6-618992b0eed0.png)